### PR TITLE
add SEO head

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This is a created with [Nextra](https://nextra.site).
  
 ## Local Development
 
-First, run `pnpm i` to install the dependencies.
+First, run `npm i` to install the dependencies.
 
-Then, run `pnpm dev` to start the development server and visit localhost:3000.
+Then, run `npm dev` to start the development server and visit localhost:3000.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "xiao-dao",
+  "name": "xaio-dao",
   "version": "0.0.1",
-  "description": "xiao-dao website",
+  "description": "xaio-dao website",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -1,7 +1,35 @@
 import React from 'react'
-import { DocsThemeConfig } from 'nextra-theme-docs'
+import { DocsThemeConfig, useConfig } from 'nextra-theme-docs'
+import { useRouter } from 'next/router'
 
 const config: DocsThemeConfig = {
+  useNextSeoProps() {
+    const { asPath } = useRouter()
+    if (asPath !== '/') {
+      return {
+        titleTemplate: '%s – XAIO DAO',
+      }
+    }
+  }, 
+  head:() => {
+    const { asPath, defaultLocale, locale } = useRouter()
+    const { frontMatter } = useConfig()
+    const url =
+      'https://xaio-dao.vercel.app/' +
+      (defaultLocale === locale ? asPath : `/${locale}${asPath}`)
+ 
+    return (
+      <>
+        <meta property="og:url" content={url} />
+        <meta property="og:title" content={frontMatter.title || 'Nextra'} />
+        <meta
+          property="og:description"
+          content={frontMatter.description || 'The next site builder'}
+        />
+      </>
+    )
+  },  
+  primaryHue: 180,
   logo: <span>XAIO DAO</span>,
   project: {
     link: 'https://github.com/XIAOAssembly/xaio-dao',
@@ -9,7 +37,7 @@ const config: DocsThemeConfig = {
   chat: {
     link: 'https://discord.gg/HgMH9xJM',
   },
-  docsRepositoryBase: 'https://github.com/XIAOAssembly/xaio-dao',
+  docsRepositoryBase: 'https://github.com/XIAOAssembly/xaio-dao/tree/main/',
   footer: {
     text: 'XAIO DAO',
   },

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -2,15 +2,15 @@ import React from 'react'
 import { DocsThemeConfig, useConfig } from 'nextra-theme-docs'
 import { useRouter } from 'next/router'
 
+
+
+
+
 const config: DocsThemeConfig = {
-  useNextSeoProps() {
-    const { asPath } = useRouter()
-    if (asPath !== '/') {
-      return {
-        titleTemplate: '%s – XAIO DAO',
-      }
-    }
-  }, 
+
+
+ 
+
   head:() => {
     const { asPath, defaultLocale, locale } = useRouter()
     const { frontMatter } = useConfig()


### PR DESCRIPTION
I added SEO to the meta dynamic head tags
[DOCS](https://nextra.site/docs/docs-theme/theme-configuration#dynamic-tags-based-on-page)
> The new code is a React component that returns a JSX fragment containing meta tags for Open Graph protocol. The Open Graph protocol is a set of meta tags that can be used to describe a web page's content to social media platforms like Facebook and Twitter.
> 
> The component uses the useRouter hook from the Next.js framework to get the current URL and locale. It also uses the useConfig hook to get the site's configuration, which includes the title and description.
> 
> The meta tags contain properties like og:url, og:title, and og:description, which are used by social media platforms to display a preview of the web page when it is shared.